### PR TITLE
Fix npm package name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-codeclimate
+# grunt-codeclimate-reporter
 > Send your coverage to codeclimate.
 
 ## Getting Started
@@ -7,13 +7,13 @@ This plugin requires Grunt `~0.4.2`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-codeclimate --save-dev
+npm install grunt-codeclimate-reporter --save-dev
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
-grunt.loadNpmTasks('grunt-codeclimate');
+grunt.loadNpmTasks('grunt-codeclimate-reporter');
 ```
 
 Setup:


### PR DESCRIPTION
in order to not accidentally install [etnbrd/grunt-codeclimate](https://github.com/etnbrd/grunt-codeclimate)

Please also consider renaming the repo to `grunt-codeclimate-reporter`

Thanks :)
