### PR TITLE
fix promisified fs.exists

### DIFF
--- a/lib/codeclimate.js
+++ b/lib/codeclimate.js
@@ -1,6 +1,6 @@
 var Promise      = require('bluebird'),
     spawnProcess = Promise.promisify(require('child_process').exec),
-    exists       = Promise.promisify(require('fs').exists),
+    fs           = require('fs'),
     path         = require('path'),
     executable   = path.join(__dirname, '..', 'node_modules', '.bin', 'codeclimate');
 
@@ -11,12 +11,20 @@ var Promise      = require('bluebird'),
 module.exports = function (options) {
   'use strict';
 
-  return exists(options.file)
-    .then(function (isPresent) {
-      if (!isPresent) {
-        return Promise.reject(new Error('Cannot find coverage report file "' + options.file + '"'));
-      }
+  function exists(file) {
+    return new Promise(function (resolve, reject) {
+      fs.exists(file, function (fileExists) {
+        if (fileExists) {
+          resolve();
+        } else {
+          reject(new Error('Cannot find coverage report file "' + file + '"'));
+        }
+      });
+    });
+  }
 
+  return exists(options.file)
+    .then(function () {
       return spawnProcess('CODECLIMATE_REPO_TOKEN=' + options.token + ' ' + executable + ' < ' + options.file);
     })
     .then(function (res) {


### PR DESCRIPTION
fs.exists callback is not being called with an error as most node callbacks are.
This prevents bluebird.promisify from working as expected.
The boolean passed into the callback that indicates if the file exists
is being misinterpreted as an error, causing the promise always be rejected.

``` js
// pseudo implementation of exists:
function exists(file, callback) {
  // ... lets assume file exists
  callback(true);
}

// kind of what promisify does internaly:
exists('foo.js', function(err, args...) {
  if (err != null) {
    reject(err);
  } else {
    resolve(args...);
  }
});
```

Documentation of fs.exists:
https://nodejs.org/api/fs.html#fs_fs_exists_path_callback

ref #5
