### PR TITLE
Use CODECLIMATE_REPO_TOKEN from ENV if not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ grunt.initConfig({
   codeclimate: {
     main: {
       options: {
-        file: 'path/to/your/lcov.info',
+        file: 'path/to/your/lcov.info', // If a path is supplied then the first lcov.info file found walking the path will be used
         token: 'your_token', // leave blank to use CODECLIMATE_REPO_TOKEN from ENV
         executable: 'path/to/executable' // leave blank to use the default executable
       }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ grunt.initConfig({
     main: {
       options: {
         file: 'path/to/your/lcov.info',
-        token: 'your_token',
+        token: 'your_token', // leave blank to use CODECLIMATE_REPO_TOKEN from ENV
         executable: 'path/to/executable' // leave blank to use the default executable
       }
     }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -6,6 +6,22 @@ var fs = require('mz/fs');
 var defaultExecutable = path.join(__dirname, '..', 'node_modules', '.bin', 'codeclimate');
 var defaultToken = process.env.CODECLIMATE_REPO_TOKEN;
 
+var getAllFiles = function(dir, name) {
+  var results = [];
+  fs.readdirSync(dir).forEach(function(file) {
+    var fullname = path.join(dir, file);
+    var stat = fs.statSync(fullname);
+    if (stat && stat.isDirectory()) {
+      results = results.concat(getAllFiles(fullname, name));
+    } else {
+      if (file.match(name)) {
+        results.push(fullname);
+      }
+    }
+  });
+  return results;
+};
+
 /**
  * @param  {object}  options
  * @return {Promise} A bluebird promise
@@ -13,14 +29,22 @@ var defaultToken = process.env.CODECLIMATE_REPO_TOKEN;
 module.exports = function reporter(options) {
   var executable = options.executable || defaultExecutable;
   var token = options.token || defaultToken;
+  var file = options.file;
+  var files;
 
   return fs.exists(options.file)
     .then(function isFilePresent(isPresent) {
       if (!isPresent) {
-        return Promise.reject(new Error(util.format('The lcov file "%s" does not exist', options.file)));
+        return Promise.reject(new Error(util.format('The lcov file "%s" does not exist', file)));
       }
-
-      return spawnProcess('CODECLIMATE_REPO_TOKEN=' + token + ' ' + executable + ' < ' + options.file);
+      if (fs.lstatSync(file).isDirectory()) {
+        files = getAllFiles(file, 'lcov.info');
+        if (files.length === 0) {
+          return Promise.reject(new Error(util.format('No lcov.info was found when searching "%s"', file)));
+        }
+        file = files[0]; // Use the first lcov.info found
+      }
+      return spawnProcess('CODECLIMATE_REPO_TOKEN=' + token + ' ' + executable + ' < \"' + file + '\"');
     })
     .then(function resolveWithResult(res) {
       return res;
@@ -29,7 +53,6 @@ module.exports = function reporter(options) {
       if (err) {
         return Promise.reject(err);
       }
-
       return Promise.reject(new Error(
         'Something went wrong during the execution of codeclimate. ' +
         'Make sure your configuration is valid'

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -4,6 +4,7 @@ var util = require('util');
 var path = require('path');
 var fs = require('mz/fs');
 var defaultExecutable = path.join(__dirname, '..', 'node_modules', '.bin', 'codeclimate');
+var defaultToken = process.env.CODECLIMATE_REPO_TOKEN;
 
 /**
  * @param  {object}  options
@@ -11,6 +12,7 @@ var defaultExecutable = path.join(__dirname, '..', 'node_modules', '.bin', 'code
  */
 module.exports = function reporter(options) {
   var executable = options.executable || defaultExecutable;
+  var token = options.token || defaultToken;
 
   return fs.exists(options.file)
     .then(function isFilePresent(isPresent) {
@@ -18,7 +20,7 @@ module.exports = function reporter(options) {
         return Promise.reject(new Error(util.format('The lcov file "%s" does not exist', options.file)));
       }
 
-      return spawnProcess('CODECLIMATE_REPO_TOKEN=' + options.token + ' ' + executable + ' < ' + options.file);
+      return spawnProcess('CODECLIMATE_REPO_TOKEN=' + token + ' ' + executable + ' < ' + options.file);
     })
     .then(function resolveWithResult(res) {
       return res;

--- a/test/codeclimate.test.js
+++ b/test/codeclimate.test.js
@@ -48,7 +48,7 @@ describe('tasks/codeclimate', function codeclimateTasktest() {
       var basePath = path.resolve(__dirname, '..');
       var bin = path.resolve(basePath, 'node_modules/.bin/codeclimate');
       var lcovFile = path.resolve(basePath, 'test/coverage.lcov');
-      var command = 'CODECLIMATE_REPO_TOKEN=' + fakeToken + ' ' + bin + ' < ' + lcovFile;
+      var command = 'CODECLIMATE_REPO_TOKEN=' + fakeToken + ' ' + bin + ' < \"' + lcovFile + '\"';
 
       execStub.callsArg(1);
 


### PR DESCRIPTION
Instead of encouraging tokens to be stored in source code, this PR enables the use of CODECLIMATE_REPO_TOKEN being fetched from ENV.
