### PR TITLE
peer dependency supports newer grunt

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sinon": "^1.15.4"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "grunt",


### PR DESCRIPTION
Per grunt recommendations now that they've released 1.0 - https://github.com/gruntjs/grunt/blob/ac9de1240b7aa286995742e2424aa2138a521c11/CHANGELOG#L10

Without this, projects that depend on this package can have intractable build conflicts as different grunt peers demand different grunt versions. Thanks!
